### PR TITLE
Updating cwac-adapter in build.gradle to 1.0.+.

### DIFF
--- a/endless/build.gradle
+++ b/endless/build.gradle
@@ -21,7 +21,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.commonsware.cwac:adapter:1.0.1'
+    compile 'com.commonsware.cwac:adapter:1.0.+'
     compile fileTree(dir: 'libs', include: '*.jar')
 }
 


### PR DESCRIPTION
Currently cwac-adapter 1.0.1 is being used, which does not have minSdkVersion set and so it forces the READ_PHONE_STATE permission to be requested. The most update version of cwac-adapter, however, has this issue resolved.